### PR TITLE
nonosec to millisec

### DIFF
--- a/java/src/Exmo.java
+++ b/java/src/Exmo.java
@@ -21,7 +21,7 @@ public class Exmo {
     private String _secret;
 
     public Exmo(String key, String secret) {
-        _nonce = System.nanoTime();
+        _nonce = System.currentTimeMillis();
         _key = key;
         _secret = secret;
     }


### PR DESCRIPTION
Returns the current value of the most precise available system timer, in nanoseconds.

This method can only be used to measure elapsed time and is not related to any other notion of system or wall-clock time. The value returned represents nanoseconds since some fixed but arbitrary time (perhaps in the future, so values may be negative). This method provides nanosecond precision, but not necessarily nanosecond accuracy. No guarantees are made about how frequently values change. Differences in successive calls that span greater than approximately 292 years (263^63 nanoseconds) will not accurately compute elapsed time due to numerical overflow.